### PR TITLE
fix missing svg exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notainc/kamon",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "This is icon system for Helpfeel Inc.",
   "repository": {
     "type": "git",
@@ -8,6 +8,7 @@
   },
   "type": "module",
   "exports": {
+    "./svg/*.svg": "./svg/*.svg",
     "./react": "./dist/react/index.js",
     "./react/*": "./dist/react/*.js"
   },


### PR DESCRIPTION
exportsフィールドを追加した際に、svgを考慮していなかったので、従来の方法で利用ができなくなっていた